### PR TITLE
Fix: pass client page locale to host for multilingual popup language

### DIFF
--- a/ph-child.php
+++ b/ph-child.php
@@ -1055,6 +1055,7 @@ if ( ! class_exists( 'PH_Child' ) ) :
 					ph.defer = true;
 					ph.charset = 'UTF-8';
 					ph.src = g + '&v=' + (new Date()).getTime();
+					ph.src += '&ph_locale=' + (d.documentElement.lang || '').replace('-', '_');
 					ph.src += t ? '&' + k + '=' + t : '';
 					s.parentNode.insertBefore(ph, s);
 				})(document, 'script', '<?php echo esc_url_raw( "//$url" ); ?>', 'ph_access_token');


### PR DESCRIPTION
## Summary

- Appends `ph_locale` from `document.documentElement.lang` to the script request URL in the `script()` method
- Allows the SureFeedback host to load the correct `.jed.json` translation file based on the **client page's language** rather than always using the host site's locale

Closes #89

## How it works

One line added to the embed snippet:
```js
ph.src += '&ph_locale=' + (d.documentElement.lang || '').replace('-', '_');
```

The `lang` attribute is set automatically by WordPress core and multilingual plugins (WPML, Polylang). The host uses this value to look up the matching translation file, falling back to its own locale if `ph_locale` is absent.

**Requires companion PR on the host plugin:** brainstormforce/project-huddle#674 (host-side fix)

## Test Plan

- [ ] Host site set to French (`fr_CA`), client site set to English
- [ ] Install updated child plugin on the English client site
- [ ] Popup on English client site should appear in **English**
- [ ] Popup on French client site should appear in **French**
- [ ] Existing installs without `ph_locale` continue to work as before (host locale used as fallback)

> Re-raise of previously closed #90 against the `release-candidate` branch.