### PR TITLE
fix: prevent XML-RPC exposure of connection secrets to non-admins

### DIFF
--- a/ph-child.php
+++ b/ph-child.php
@@ -5,7 +5,7 @@
  * Description: Collect note-style feedback from your client’s websites and sync them with your SureFeedback parent project.
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
- * Version: 1.2.12
+ * Version: 1.2.13
  *
  * Requires at least: 4.7
  * Tested up to: 7.0
@@ -66,6 +66,17 @@ if ( ! class_exists( 'PH_Child' ) ) :
 		protected $whitelist_option_names = array();
 
 		/**
+		 * Connection options that hold secrets and must never be readable
+		 * by non-administrators over XML-RPC.
+		 *
+		 * @var array
+		 */
+		protected $sensitive_option_names = array(
+			'ph_child_access_token',
+			'ph_child_signature',
+		);
+
+		/**
 		 * Get things going
 		 */
 		public function __construct() {
@@ -120,6 +131,11 @@ if ( ! class_exists( 'PH_Child' ) ) :
 
 			// whitelist our blog options.
 			add_filter( 'xmlrpc_blog_options', array( $this, 'whitelist_option' ) );
+
+			// prevent the connection secrets from leaking to non-admins over XML-RPC (wp.getOptions).
+			foreach ( $this->sensitive_option_names as $sensitive_option ) {
+				add_filter( 'option_' . $sensitive_option, array( $this, 'protect_sensitive_option_on_xmlrpc' ) );
+			}
 
 			// maybe disconnect from parent site.
 			add_action( 'admin_init', array( $this, 'maybe_disconnect' ) );
@@ -378,6 +394,34 @@ if ( ! class_exists( 'PH_Child' ) ) :
 			}
 
 			return $options;
+		}
+
+		/**
+		 * Mask sensitive connection secrets during XML-RPC reads.
+		 *
+		 * WordPress core's wp.getOptions method returns option values to any
+		 * authenticated user regardless of capability - the readonly flag only
+		 * gates writes, not reads. Because the plugin whitelists its connection
+		 * options so the parent site can configure them via wp.setOptions, the
+		 * access token and signature would otherwise be readable by any logged-in
+		 * user, including Subscribers. This masks those values on read while an
+		 * XML-RPC request is being served by a user who cannot manage options.
+		 *
+		 * The admin-authenticated connection handshake (parent site), the
+		 * front-end script loader and the REST endpoints are unaffected, as they
+		 * either run outside an XML-RPC request or with the manage_options
+		 * capability.
+		 *
+		 * @param mixed $value The stored option value.
+		 *
+		 * @return mixed Empty string when the read must be blocked, original value otherwise.
+		 */
+		public function protect_sensitive_option_on_xmlrpc( $value ) {
+			if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && ! current_user_can( 'manage_options' ) ) {
+				return '';
+			}
+
+			return $value;
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://surefeedback.com
 Tags: project, huddle, child, feedback, design
 Requires at least: 4.7
 Tested up to: 7.0
-Stable tag: 1.2.12
+Stable tag: 1.2.13
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -47,7 +47,10 @@ All you need to do is install the plugin on the site you want feedback on and it
 The purpose of this plugin is to make it simple to get targeted feedback from clients on web designs. All you have to do is install the [SureFeedback](https://surefeedback.com) plugin and let your clients select areas of your design to add their own comments. Everything is tracked within the plugin. It's so easy to use!
 
 == Changelog ==
-= 1.2.12 = 
+= 1.2.13 =
+* Fix: Prevented the connection access token and signature from being readable by non-administrator users via the XML-RPC wp.getOptions method. Props to Patchstack for privately reporting it to our team. Please make sure you are using the latest version on your website.
+
+= 1.2.12 =
 * Improvement: Compatibility to WordPress 7.0
 
 = 1.2.11 = 


### PR DESCRIPTION
## Summary

Fixes a **Sensitive Data Exposure** vulnerability (Patchstack, private report) in SureFeedback Client Site ≤ 1.2.12.

The plugin registers its six connection options on WordPress's XML-RPC blog-options map (`xmlrpc_blog_options`) so the parent site can configure them via `wp.setOptions`. However, core's `wp.getOptions` returns option **values** to any authenticated user regardless of capability — the `readonly` flag only gates *writes*, not *reads*. As a result, **any logged-in user, down to a Subscriber, could read `ph_child_access_token` and `ph_child_signature`** by calling `wp.getOptions` over `/xmlrpc.php`.

Impact: `ph_child_signature` is the parent project's identity signing key. Leaking it lets an attacker forge `hash_hmac('sha256', $email, $signature_key)` signatures and pass the parent's `PH_Signature_Checker`, enabling access-link auto-login and project-comment access on the parent hub. CVSS 7.5 (High).

## Root cause

- `ph-child.php` → `whitelist_option()` adds the connection options (incl. the two secrets) to the XML-RPC map.
- `wp-includes/class-wp-xmlrpc-server.php` → `_getOptions()` assigns `value` unconditionally and only flips `readonly` for non-admins.

Setting `'readonly' => true` in the plugin would **not** fix reads (and would break the connection handshake by blocking `wp.setOptions` writes), so that is deliberately not the approach.

## Fix

Keep the options writable (connection handshake intact), but **mask the two secret values on read** whenever the request is XML-RPC *and* the user lacks `manage_options`:

- New `protect_sensitive_option_on_xmlrpc()` hooked on `option_ph_child_access_token` and `option_ph_child_signature`.
- Returns `''` only when `XMLRPC_REQUEST` is set and `! current_user_can('manage_options')`.

### Why every legitimate path is unaffected

| Path | Runs during XML-RPC? | Capability | Result |
|------|----------------------|------------|--------|
| Parent connect — `wp.setOptions` (write) | yes | admin (`manage_options`) | write path; filter is read-only, no effect |
| Parent verify — `wp.getOptions` (read) | yes | admin (`manage_options`) | real value returned → connection validates |
| Front-end script loader `script()` | no (`wp_footer`) | — | unaffected |
| Custom REST `surefeedback/v1` | no (`REST_REQUEST`) | token-gated | unaffected |
| **Subscriber `wp.getOptions` (attack)** | **yes** | **not admin** | **`''` returned → secret blocked** |

## Test plan

- [ ] Connect a child site to a parent project → verify connection still succeeds (setOptions write + admin getOptions read).
- [ ] As a Subscriber, `POST /xmlrpc.php` with `wp.getOptions` for `ph_child_signature` / `ph_child_access_token` → values come back **empty**.
- [ ] Repeat with the options array omitted (dump-all variant) → the two secrets are **empty**, non-sensitive options unaffected.
- [ ] Front-end feedback script + `surefeedback/v1` REST still function normally.
- [ ] Disconnect flow still clears all options.

## Changed files

- `ph-child.php` — fix + version bump `1.2.12 → 1.2.13`
- `readme.txt` — stable tag + changelog entry
